### PR TITLE
use ansi strftime format

### DIFF
--- a/keep/utils.py
+++ b/keep/utils.py
@@ -20,7 +20,7 @@ api_url = 'https://keep-cli.herokuapp.com'
 
 def check_update(forced=False):
     update_check_file = os.path.join(dir_path, 'update_check.json')
-    today = datetime.date.today().strftime("%D")
+    today = datetime.date.today().strftime("%m/%d/%Y")
     if os.path.exists(update_check_file):
         dates = json.loads(open(update_check_file, 'r').read())
     else:


### PR DESCRIPTION
Address #12 by using ansi strftime format. Using %d only captures the day of the month. However `strftime("%m/%d/%Y")` captures month, day and year, identically to the current implementation.