### PR TITLE
Commands with parameters 

### DIFF
--- a/keep/commands/cmd_run.py
+++ b/keep/commands/cmd_run.py
@@ -3,11 +3,13 @@ import click
 from keep import cli, utils
 
 
-@click.command('run', short_help='Executes a saved command.')
+@click.command('run', short_help='Executes a saved command.',
+               context_settings=dict(ignore_unknown_options=True))
 @click.argument('pattern')
+@click.argument('arguments', nargs=-1, type=click.UNPROCESSED)
 @click.option('--safe', is_flag=True, help='Ignore missing arguments')
 @cli.pass_context
-def cli(ctx, pattern, safe):
+def cli(ctx, pattern, arguments, safe):
     """Executes a saved command."""
 
     matches = utils.grep_commands(pattern)
@@ -31,9 +33,14 @@ def cli(ctx, pattern, safe):
             pcmd = utils.create_pcmd(cmd)
             params = utils.get_params_in_pcmd(pcmd)
 
+            arguments = list(arguments)
             kargs = {}
             for p in params:
-                if not safe:
+                if arguments:
+                    val = arguments.pop(0)
+                    click.echo("{}: {}".format(p, val))
+                    kargs[p] = val
+                elif not safe:
                     val = click.prompt("Enter value for '{}'".format(p))
                     kargs[p] = val
             click.echo("\n")

--- a/keep/commands/cmd_run.py
+++ b/keep/commands/cmd_run.py
@@ -5,9 +5,11 @@ from keep import cli, utils
 
 @click.command('run', short_help='Executes a saved command.')
 @click.argument('pattern')
+@click.option('--safe', is_flag=True, help='Ignore missing arguments')
 @cli.pass_context
-def cli(ctx, pattern):
+def cli(ctx, pattern, safe):
     """Executes a saved command."""
+
     matches = utils.grep_commands(pattern)
     if matches:
         click.echo("\n\n")
@@ -17,18 +19,30 @@ def cli(ctx, pattern):
             click.secho("$ {} :: {}".format(cmd, desc), fg='green')
         click.echo("\n\n")
 
-        val = 1
+        selection = 1
         while True and len(matches) > 1:
-            val = click.prompt("Choose command to execute [1-{}] (0 to cancel)"
-                               .format(len(matches)), type=int)
-            if val in range(len(matches) + 1):
+            selection = click.prompt("Choose command to execute [1-{}] (0 to cancel)"
+                                     .format(len(matches)), type=int)
+            if selection in range(len(matches) + 1):
                 break
             click.echo("Number is not in range")
-        if val > 0:
-            cmd, desc = matches[val - 1]
-            command = "$ {} :: {}".format(cmd, desc)
+        if selection > 0:
+            cmd, desc = matches[selection - 1]
+            pcmd = utils.create_pcmd(cmd)
+            params = utils.get_params_in_pcmd(pcmd)
+
+            kargs = {}
+            for p in params:
+                if not safe:
+                    val = click.prompt("Enter value for '{}'".format(p))
+                    kargs[p] = val
+            click.echo("\n")
+
+            final_cmd = utils.substitute_pcmd(pcmd, kargs, safe)
+
+            command = "$ {} :: {}".format(final_cmd, desc)
             if click.confirm("Execute\n\t{}\n\n?".format(command), default=True):
-                os.system(cmd)
+                os.system(final_cmd)
     elif matches == []:
         click.echo('No saved commands matches the pattern {}'.format(pattern))
     else:

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -204,3 +204,24 @@ def grep_commands(pattern):
             if i_keyword == keywords_len:
                 result.append((cmd, desc))
     return result
+
+
+def create_pcmd(command):
+    return string.Template(command)
+
+
+def get_params_in_pcmd(pcmd):
+    patt = pcmd.pattern
+    res = []
+    for match in re.findall(patt, pcmd.template):
+        param = match[1] or match[2]
+        if param and param not in res:
+            res.append(param)
+    return res
+
+
+def substitute_pcmd(pcmd, kargs, safe=False):
+    if safe:
+        return pcmd.safe_substitute(**kargs)
+    else:
+        return pcmd.substitute(**kargs)


### PR DESCRIPTION
- Added placeholders in commands using python3 [string.Template](https://docs.python.org/3/library/string.html#template-strings). #11
 
- Added '--safe' option to 'keep run' that will ignore missing arguments.
- Added options to send the arguments to 'keep run' , this way you can use the shell completion.

Examples:
```
$ keep run "tar"

 1	$ tar zxvf $tarfile -C $dest :: Extract tar content to destination

Enter value for 'tarfile': /path/to/tar
Enter value for 'dest': /my/folder/

Execute
	$ tar zxvf /path/to/tar -C /my/folder/ :: Extract tar content to destination
? [Y/n]: 
```

```
$ keep run "test"

 1	$ replace $this and /path/to/${this}/file but not $$this :: test

Enter value for 'this': TEST

Execute
	$ replace TEST and /path/to/TEST/file but not $this :: test
? [Y/n]: 
```

Sending arguments from command line:
```
$ keep run "grep" /path/to/dir "data[0-9]+" "> file" 

 1	$ grep -irnw $dir -e $pattern $out :: Look for a regex pattern inside files

dir: /path/to/dir
pattern: data[0-9]+
out: > file

Execute
	$ grep -irnw /path/to/dir -e file_[0-9]+ > file :: Look for a regex pattern inside files
? [Y/n]:
```

Missing arguments:

```
$ keep run "grep" /path/to/dir "data[0-9]+"

 1	$ grep -irnw $dir -e $pattern $out :: Look for a regex pattern inside files

dir: /path/to/dir
pattern: data[0-9]+
Enter value for 'out':  

Execute
	$ grep -irnw /path/to/dir -e data[0-9]+   :: Look for a regex pattern inside files
? [Y/n]:
```