### PR TITLE
Added "edit" command.

### DIFF
--- a/keep/commands/cmd_edit.py
+++ b/keep/commands/cmd_edit.py
@@ -1,0 +1,25 @@
+import click
+from keep import cli, utils
+
+
+@click.command('edit', short_help='Edit a saved command.')
+@click.option('--editor', help='Editor to use')
+@cli.pass_context
+def cli(ctx, editor):
+    """Edit saved commands."""
+
+    commands = utils.read_commands()
+    if commands is []:
+        click.echo("No commands to edit, Add one by 'keep new'. ")
+    else:
+        edit_header = "# Unchanged file will abort the operation\n"
+        new_commands = utils.edit_commands(commands, editor, edit_header)
+        if new_commands and new_commands != commands:
+            click.echo("Replace:\n")
+            click.secho("\t{}".format('\n\t'.join(utils.format_commands(commands))),
+                        fg="green")
+            click.echo("With:\n\t")
+            click.secho("\t{}".format('\n\t'.join(utils.format_commands(new_commands))),
+                        fg="green")
+            if click.confirm("", default=False):
+                utils.write_commands(new_commands)

--- a/keep/commands/cmd_rm.py
+++ b/keep/commands/cmd_rm.py
@@ -9,27 +9,12 @@ def cli(ctx, pattern):
     """Deletes a saved command."""
     matches = utils.grep_commands(pattern)
     if matches:
-        click.echo("\n\n")
-        for idx, match in enumerate(matches):
-            cmd, desc = match
-            click.secho(" " + str(idx + 1) + "\t", nl=False, fg='yellow')
-            click.secho("$ {} :: {}".format(cmd, desc), fg='green')
-        click.echo("\n\n")
-
-        val = 1
-        while True and len(matches) > 1:
-            val = click.prompt("Choose command to remove [1-{}] (0 to cancel)"
-                               .format(len(matches)), type=int)
-            if val in range(len(matches) + 1):
-                break
-            click.echo("Number is not in range")
-        if val > 0:
-            cmd, desc = matches[val - 1]
+        selected = utils.select_command(matches)
+        if selected >= 0:
+            cmd, desc = matches[selected]
             command = "$ {} :: {}".format(cmd, desc)
             if click.confirm("Remove\n\t{}\n\n?".format(command), default=True):
-                commands = utils.read_commands()
-                del commands[cmd]
-                utils.write_commands(commands)
+                utils.remove_command(cmd)
                 click.echo('Command successfully removed!')
     elif matches == []:
         click.echo('No saved commands matches the pattern {}'.format(pattern))

--- a/keep/commands/cmd_run.py
+++ b/keep/commands/cmd_run.py
@@ -14,22 +14,9 @@ def cli(ctx, pattern, arguments, safe):
 
     matches = utils.grep_commands(pattern)
     if matches:
-        click.echo("\n\n")
-        for idx, match in enumerate(matches):
-            cmd, desc = match
-            click.secho(" " + str(idx + 1) + "\t", nl=False, fg='yellow')
-            click.secho("$ {} :: {}".format(cmd, desc), fg='green')
-        click.echo("\n\n")
-
-        selection = 1
-        while True and len(matches) > 1:
-            selection = click.prompt("Choose command to execute [1-{}] (0 to cancel)"
-                                     .format(len(matches)), type=int)
-            if selection in range(len(matches) + 1):
-                break
-            click.echo("Number is not in range")
-        if selection > 0:
-            cmd, desc = matches[selection - 1]
+        selected = utils.select_command(matches)
+        if selected >= 0:
+            cmd, desc = matches[selected]
             pcmd = utils.create_pcmd(cmd)
             params = utils.get_params_in_pcmd(pcmd)
 

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -152,21 +152,13 @@ def register():
     sys.exit(0)
 
 
-def remove_command(ctx, cmd):
-    json_path = os.path.join(dir_path, 'commands.json')
-    commands = {}
-    if os.path.exists(json_path):
-        commands = json.loads(open(json_path, 'r').read())
-    else:
-        click.echo('No commands to remove. Run `keep new` to add one.')
-
+def remove_command(cmd):
+    commands = read_commands()
     if cmd in commands:
         del commands[cmd]
-        click.echo('Command successfully removed!')
-        with open(json_path, 'w') as f:
-            f.write(json.dumps(commands))
     else:
         click.echo('Command - {} - does not exist.'.format(cmd))
+    write_commands(commands)
 
 
 def save_command(cmd, desc):
@@ -211,6 +203,25 @@ def grep_commands(pattern):
             if i_keyword == keywords_len:
                 result.append((cmd, desc))
     return result
+
+
+def select_command(commands):
+    click.echo("\n\n")
+    for idx, command in enumerate(commands):
+        cmd, desc = command
+        click.secho(" " + str(idx + 1) + "\t", nl=False, fg='yellow')
+        click.secho("$ {} :: {}".format(cmd, desc), fg='green')
+    click.echo("\n\n")
+
+    selection = 1
+    while True and len(commands) > 1:
+        selection = click.prompt(
+            "Choose command to execute [1-{}] (0 to cancel)"
+            .format(len(commands)), type=int)
+        if selection in range(len(commands) + 1):
+            break
+        click.echo("Number is not in range")
+    return selection - 1
 
 
 def create_pcmd(command):


### PR DESCRIPTION
Hey, 
Added a simple edit command that will allow you to open all stored keep commands using
an editor of you choice.
The command is really basic and there are many things that can be improved like:
* Adding pattern argument that allows editing part of the commands
* Show only the differences between new and old commands after editing
* Backup commands.json file before overwriting
* Changing the syntax of the editor to something easier

Some examples:
```
$ keep list
Command                        Description
-----------------------------  -------------
$ echo "hello world"           test
$ grep -Iirnw $dir -e "$patt"  test grep
$ ls ~/old/files/              test ls

$ keep edit
```

How it looks in the editor:
```
# Unchanged file will abort the operation

"echo \"hello world\"" :: "test"
"grep -Iirnw $dir -e \"$patt\"" :: "test grep"
"ls ~/old/files/" :: "test ls"
```

After editing the last command:
```
Replace:

        $ echo "hello world" :: test
        $ grep -Iirnw $dir -e "$patt" :: test grep
        $ ls ~/old/files/ :: test ls
With:

        $ echo "hello world" :: test
        $ grep -Iirnw $dir -e "$patt" :: test grep
        $ ls -l ~/new/files :: test ls
 [y/N]: 
```
Can also used to add / remove commands:
```
Replace:

        $ echo "hello world" :: test
        $ grep -Iirnw $dir -e "$patt" :: test grep
        $ ls ~/old/files/ :: test ls
With:

        $ ls ~/old/files/ :: test ls
        $ echo " new command " :: test new
 [y/N]: 
```

By default the command will use `$EDITOR` as your editor, but you can call it with any editor:
`keep edit --editor vim`
