### PR TITLE
Added support for default values in commands templates

### DIFF
--- a/keep/commands/cmd_run.py
+++ b/keep/commands/cmd_run.py
@@ -18,18 +18,22 @@ def cli(ctx, pattern, arguments, safe):
         if selected >= 0:
             cmd, desc = matches[selected]
             pcmd = utils.create_pcmd(cmd)
-            params = utils.get_params_in_pcmd(pcmd)
+            raw_params, params, defaults = utils.get_params_in_pcmd(pcmd)
 
             arguments = list(arguments)
             kargs = {}
-            for p in params:
+            for r, p, d in zip(raw_params, params, defaults):
                 if arguments:
                     val = arguments.pop(0)
                     click.echo("{}: {}".format(p, val))
-                    kargs[p] = val
-                elif not safe:
-                    val = click.prompt("Enter value for '{}'".format(p))
-                    kargs[p] = val
+                    kargs[r] = val
+                elif safe:
+                    if d:
+                        kargs[r] = d
+                else:
+                    p_default = d if d else None
+                    val = click.prompt("Enter value for '{}'".format(p), default=p_default)
+                    kargs[r] = val
             click.echo("\n")
 
             final_cmd = utils.substitute_pcmd(pcmd, kargs, safe)

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -263,7 +263,7 @@ def format_commands(commands):
 def create_pcmd(command):
     class KeepCommandTemplate(string.Template):
         default_sep = '='
-        idpattern = r'[_a-z][_\a-z0-9{}]*'.format(default_sep)
+        idpattern = r'[_a-z][_a-z0-9{}]*'.format(default_sep)
 
         def __init__(self, template):
             super().__init__(template)

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -261,17 +261,28 @@ def format_commands(commands):
 
 
 def create_pcmd(command):
-    return string.Template(command)
+    class KeepCommandTemplate(string.Template):
+        idpattern = r'[_a-z][_\-a-z0-9]*'
+
+        def __init__(self, template):
+            super().__init__(template)
+    return KeepCommandTemplate(command)
 
 
 def get_params_in_pcmd(pcmd):
     patt = pcmd.pattern
-    res = []
+    params = []
+    defaults = []
+    raw = []
     for match in re.findall(patt, pcmd.template):
-        param = match[1] or match[2]
-        if param and param not in res:
-            res.append(param)
-    return res
+        var = match[1] or match[2]
+        svar = var.split('-')
+        p, d = svar[0], '-'.join(svar[1:])
+        if p and p not in params:
+            raw.append(var)
+            params.append(p)
+            defaults.append(d)
+    return raw, params, defaults
 
 
 def substitute_pcmd(pcmd, kargs, safe=False):

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -262,7 +262,8 @@ def format_commands(commands):
 
 def create_pcmd(command):
     class KeepCommandTemplate(string.Template):
-        idpattern = r'[_a-z][_\-a-z0-9]*'
+        default_sep = '='
+        idpattern = r'[_a-z][_\a-z0-9{}]*'.format(default_sep)
 
         def __init__(self, template):
             super().__init__(template)
@@ -276,8 +277,8 @@ def get_params_in_pcmd(pcmd):
     raw = []
     for match in re.findall(patt, pcmd.template):
         var = match[1] or match[2]
-        svar = var.split('-')
-        p, d = svar[0], '-'.join(svar[1:])
+        svar = var.split(pcmd.default_sep)
+        p, d = svar[0], pcmd.default_sep.join(svar[1:])
         if p and p not in params:
             raw.append(var)
             params.append(p)


### PR DESCRIPTION
Added Basic support for defaults in templates.
Using '-' as a separator between variable name and default value.
Using '--safe' option with "keep run" will now use default if possible.

```
$ keep run "git"

 1      $ git pull ${remote-origin} $branch-master :: git

Enter value for 'remote' [origin]: 
Enter value for 'branch' [master]: 

Execute
        $ git pull origin master :: git

? [Y/n]:
```

```
$ keep run "git" --safe

 1      $ git pull ${remote-origin} $branch-master :: git

Execute
        $ git pull origin master :: git

? [Y/n]: 
```
```
$ keep run "git"

 1      $ git pull ${remote-origin} $branch-master :: git

Enter value for 'remote' [origin]: 
Enter value for 'branch' [master]: feature

Execute
        $ git pull origin feature :: git

? [Y/n]: 
```

```