### PR TITLE
Added support for command 'alias'

### DIFF
--- a/keep/commands/cmd_new.py
+++ b/keep/commands/cmd_new.py
@@ -7,6 +7,7 @@ def cli(ctx):
     """Saves a new command"""
     cmd = click.prompt('Command')
     desc = click.prompt('Description ')
-    utils.save_command(cmd, desc)
+    alias = click.prompt('Alias (optional)', default='')
+    utils.save_command(cmd, desc, alias)
 
     utils.log(ctx, 'Saved the new command - {} - with the description - {}.'.format(cmd, desc))


### PR DESCRIPTION
Hey, Implemented feature #35 .

Basically means that in grepping commands, if there is a match with the command alias field then that single command is returned.
This is the migration script I used:
```
from keep import utils
import json

commands = utils.read_commands()
new_cmd = {}
for cmd, desc in commands.items():
    fields = {'desc': desc, 'alias': ""}
    new_cmd[cmd] = fields


json_path = 'new_commands.json'
with open(json_path, 'w') as f:
    f.write(json.dumps(new_cmd))
```
So the new alias field is by default an empty string.

Feel free to comment about the code or make your own changes.

Example:
```
$ keep list
Command   Alias      Description
----------    -------     -------------
$ echo "1"  echo        test1
$ echo "2"  mycmd    test2
$ echo "3"  myecho   test3
```
```
$ keep run echo

 1	$ echo "1" :: test1

Execute
	$ echo "1" :: test1

? [Y/n]: 
```

```
$ keep new
Command: echo 4
Description : test4
Alias (optional) []: 
```