### PR TITLE
hot-fix(pull) create file if doesn’t exist when pulling

### DIFF
--- a/keep/commands/cmd_pull.py
+++ b/keep/commands/cmd_pull.py
@@ -22,6 +22,7 @@ def cli(ctx):
     if click.confirm(prompt_str, abort=True):
         os.remove(commands_file_path)
 
-    with open(commands_file_path, 'w') as commands_file:
+    """Using `w+` so it create the file if doesn't exist (Issue #64)"""
+    with open(commands_file_path, 'w+') as commands_file:
         commands_file.write(gist.files['commands.json'].content)
     click.echo("Done!")

--- a/keep/commands/cmd_pull.py
+++ b/keep/commands/cmd_pull.py
@@ -20,7 +20,7 @@ def cli(ctx):
     gist_url = f"https://gist.github.com/{token['gist']}"
     prompt_str = f"[CRITICAL] Replace local commands with GitHub gist\nGist URL : {gist_url} ?"
     if click.confirm(prompt_str, abort=True):
-        os.remove(commands_file_path)
+        pass
 
     """Using `w+` so it create the file if doesn't exist (Issue #64)"""
     with open(commands_file_path, 'w+') as commands_file:


### PR DESCRIPTION
Fix #64 

The bug in #64 was in `os.remove` because the file didn’t exist so it couldn’t be removed, so I removed the `remove` and change the open file mode to `w+`

> `w+` create file if it doesn't exist and open it in (over)write mode
> [it overwrites the file if it already exists]