### PR TITLE
Add '--no-confirm' option for run command

### DIFF
--- a/keep/commands/cmd_run.py
+++ b/keep/commands/cmd_run.py
@@ -8,8 +8,9 @@ from keep import cli, utils
 @click.argument('pattern', required=False)
 @click.argument('arguments', nargs=-1, type=click.UNPROCESSED)
 @click.option('--safe', is_flag=True, help='Ignore missing arguments')
+@click.option('-n', '--no-confirm', is_flag=True, help='Don\'t ask confirm before running')
 @cli.pass_context
-def cli(ctx, pattern, arguments, safe):
+def cli(ctx, pattern, arguments, safe, no_confirm):
     """Executes a saved command."""
 
     if not pattern:
@@ -40,9 +41,15 @@ def cli(ctx, pattern, arguments, safe):
 
             final_cmd = utils.substitute_pcmd(pcmd, kargs, safe)
 
-            command = "$ {} :: {}".format(final_cmd, desc)
-            if click.confirm("Execute\n\t{}\n\n?".format(command), default=True):
+            if no_confirm:
+                isconfirmed = True
+            else:
+                command = "$ {} :: {}".format(final_cmd, desc)
+                isconfirmed = click.confirm("Execute\n\t{}\n\n?".format(command), default=True)
+
+            if isconfirmed:
                 os.system(final_cmd)
+
     elif matches == []:
         click.echo('No saved commands matches the pattern {}'.format(pattern))
     else:

--- a/tutorial.md
+++ b/tutorial.md
@@ -66,13 +66,13 @@ Enter value for 'dest': /my/folder/
 
 Execute
 	$ tar zxvf /path/to/tar -C /my/folder/ :: Extract tar content to destination
-? [Y/n]: 
+? [Y/n]:
 ```
 
 - Parameters can also be passed directly into commands.
 
 ```bash
-$ keep run "grep" /path/to/dir "data[0-9]+" "> file" 
+$ keep run "grep" /path/to/dir "data[0-9]+" "> file"
 
  1	$ grep -irnw $dir -e $pattern $out :: Look for a regex pattern inside files
 
@@ -94,9 +94,20 @@ $ keep run "grep" /path/to/dir "data[0-9]+"
 
 dir: /path/to/dir
 pattern: data[0-9]+
-Enter value for 'out':  
+Enter value for 'out':
 
 Execute
 	$ grep -irnw /path/to/dir -e data[0-9]+   :: Look for a regex pattern inside files
 ? [Y/n]:
+```
+
+- Disable confirm message before run
+```bash
+$ keep run "tar" -n
+
+ 1  $ tar zxvf $tarfile -C $dest :: Extract tar content to destination
+
+Enter value for 'tarfile': /path/to/tar
+Enter value for 'dest': /my/folder/
+
 ```


### PR DESCRIPTION
User can to disable confirm message before run:

```bash
$ keep run "tar" -n

 1  $ tar zxvf $tarfile -C $dest :: Extract tar content to destination

Enter value for 'tarfile': /path/to/tar
Enter value for 'dest': /my/folder/

```