### PR TITLE
Compact output for keep run

### DIFF
--- a/keep/commands/cmd_run.py
+++ b/keep/commands/cmd_run.py
@@ -28,29 +28,28 @@ def cli(ctx, pattern, arguments, safe, no_confirm):
             for r, p, d in zip(raw_params, params, defaults):
                 if arguments:
                     val = arguments.pop(0)
-                    click.echo("{}: {}".format(p, val))
+                    click.echo(f"{p}: {val}", err=True)
                     kargs[r] = val
                 elif safe:
                     if d:
                         kargs[r] = d
                 else:
                     p_default = d if d else None
-                    val = click.prompt("Enter value for '{}'".format(p), default=p_default)
+                    val = click.prompt(f"Enter value for '{p}'", default=p_default, err=True)
                     kargs[r] = val
-            click.echo("\n")
 
             final_cmd = utils.substitute_pcmd(pcmd, kargs, safe)
 
             if no_confirm:
                 isconfirmed = True
             else:
-                command = "$ {} :: {}".format(final_cmd, desc)
-                isconfirmed = click.confirm("Execute\n\t{}\n\n?".format(command), default=True)
+                command = f"$ {final_cmd} :: {desc}"
+                isconfirmed = click.confirm(f"Execute\n\t{command}\n?", default=True, err=True)
 
             if isconfirmed:
                 os.system(final_cmd)
 
     elif matches == []:
-        click.echo('No saved commands matches the pattern {}'.format(pattern))
+        click.echo(f'No saved commands matches the pattern {pattern}', err=True)
     else:
-        click.echo("No commands to run, Add one by 'keep new'. ")
+        click.echo("No commands to run, Add one by 'keep new'. ", err=True)

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -239,10 +239,10 @@ def select_command(commands):
         cmd, desc = command
         click.secho(f" {idx + 1} \t", nl=False, fg='yellow', err=True)
         click.secho(f" {cmd} :: {desc}", fg='green', err=True)
-    click.echo("", err=True)
 
     selection = 1
     while True and len(commands) > 1:
+        click.echo("", err=True)
         selection = click.prompt(
             f"Select a command [1-{len(commands)}] (0 to cancel)",
             type=int,

--- a/keep/utils.py
+++ b/keep/utils.py
@@ -234,21 +234,23 @@ def grep_commands(pattern):
 
 
 def select_command(commands):
-    click.echo("\n\n")
+    click.echo("", err=True)
     for idx, command in enumerate(commands):
         cmd, desc = command
-        click.secho(" " + str(idx + 1) + "\t", nl=False, fg='yellow')
-        click.secho("$ {} :: {}".format(cmd, desc), fg='green')
-    click.echo("\n\n")
+        click.secho(f" {idx + 1} \t", nl=False, fg='yellow', err=True)
+        click.secho(f" {cmd} :: {desc}", fg='green', err=True)
+    click.echo("", err=True)
 
     selection = 1
     while True and len(commands) > 1:
         selection = click.prompt(
-            "Select a command [1-{}] (0 to cancel)"
-            .format(len(commands)), type=int)
+            f"Select a command [1-{len(commands)}] (0 to cancel)",
+            type=int,
+            err=True
+        )
         if selection in range(len(commands) + 1):
             break
-        click.echo("Number is not in range")
+        click.echo("Number is not in range", err=True)
     return selection - 1
 
 


### PR DESCRIPTION
Compact output for `keep run`, should fix #39 

```sh
❯ keep run

 1   ls -larth :: ls
 2   iptables -I INPUT -p ${protocol} -m ${protocol} --dport ${port} -j ACCEPT :: iptables open port

Select a command [1-2] (0 to cancel): 1
Execute
        $ ls -larth :: ls
? [Y/n]: Y
total 80
drwxr-xr-x   8 rahuli  staff   256B Feb 18 18:33 ..
-rw-r--r--   1 rahuli  staff   711B Feb 18 18:33 .gitignore
-rw-r--r--   1 rahuli  staff   168B Feb 18 18:33 .pep8speaks.yml
-rw-r--r--   1 rahuli  staff   1.0K Feb 18 18:33 LICENSE.md
-rw-r--r--   1 rahuli  staff    59B Feb 18 18:33 MANIFEST.in
drwxr-xr-x   4 rahuli  staff   128B Feb 18 18:33 completions
drwxr-xr-x   3 rahuli  staff    96B Feb 18 18:33 data
-rwxr-xr-x   1 rahuli  staff   152B Feb 18 18:33 release.sh
-rw-r--r--   1 rahuli  staff    47B Feb 18 18:33 requirements.txt
-rw-r--r--   1 rahuli  staff   3.8K Feb 18 18:33 README.md
-rw-r--r--   1 rahuli  staff   1.0K Feb 18 18:33 setup.py
-rw-r--r--   1 rahuli  staff   5.5K Feb 18 18:33 tutorial.md
drwxr-xr-x  16 rahuli  staff   512B Feb 18 18:38 .
drwxr-xr-x   3 rahuli  staff    96B Feb 18 18:38 .vscode
drwxr-xr-x  12 rahuli  staff   384B Feb 18 19:25 .git
drwxr-xr-x  10 rahuli  staff   320B Feb 18 19:25 keep
```

Also redirecting the output from the commands to `stderr` which enabling piping `keep run` commands

```sh
❯ keep run -n ls | awk '{print $9}'

 1   ls -larth :: ls

..
.gitignore
.pep8speaks.yml
LICENSE.md
MANIFEST.in
completions
data
release.sh
requirements.txt
README.md
setup.py
tutorial.md
.
.vscode
.git
keep
```