### PR TITLE
Typo: fix the link for the edit command

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -14,7 +14,7 @@
 # Commands
 
 <dl>
-  <dt><a href="https://github.com/OrkoHunter/keep/blob/master/keep/commands/cmd_update.py">edit</a></dt>
+  <dt><a href="https://github.com/OrkoHunter/keep/blob/master/keep/commands/cmd_edit.py">edit</a></dt>
   <dd>Edit the saved commands and their descriptions.</dd>
 
   <dt><a href="https://github.com/OrkoHunter/keep/blob/master/keep/commands/cmd_grep.py">grep</a> "PATTERN"</dt>


### PR DESCRIPTION
Updated `Tutorial.md` to fix the link for the `edit` command, that was accidentally linking to the `cmd_update.py` file instead of `cmd_edit.py`.