### PR TITLE
add arguments to cmd_new.py to allow no input creation of commands

### DIFF
--- a/keep/commands/cmd_new.py
+++ b/keep/commands/cmd_new.py
@@ -1,13 +1,19 @@
 import click
 from keep import cli, utils
 
-@click.command('new', short_help='Saves a new command.')
+@click.command("new", short_help="Saves a new command.")
+@click.option("--cmd", help="The command to save")
+@click.option("--desc", help="The description of the command")
+@click.option("--alias", default="", help="The alias of the command")
 @cli.pass_context
-def cli(ctx):
+def cli(ctx, cmd, desc, alias):
     """Saves a new command"""
-    cmd = click.prompt('Command')
-    desc = click.prompt('Description ')
-    alias = click.prompt('Alias (optional)', default='')
+    if not cmd:
+        cmd = click.prompt("Command")
+    if not desc:
+        desc = click.prompt("Description")
+    if not alias:
+        alias = click.prompt("Alias (optional)", default="")
     utils.save_command(cmd, desc, alias)
 
-    utils.log(ctx, 'Saved the new command - {} - with the description - {}.'.format(cmd, desc))
+    utils.log(ctx, "Saved the new command - {} - with the description - {}.".format(cmd, desc))


### PR DESCRIPTION
To test use the new functionality use:
```keep new --cmd hello1 --desc "echo 1" --alias " "```

or the original command to ensure it still works like original
```keep new```